### PR TITLE
Add Dynamics 365 opportunity plugin

### DIFF
--- a/AddOldOwnerToSalesTeamPlugin.cs
+++ b/AddOldOwnerToSalesTeamPlugin.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Linq;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Microsoft.Crm.Sdk.Messages;
+
+public class AddOldOwnerToSalesTeamPlugin : IPlugin
+{
+    public void Execute(IServiceProvider serviceProvider)
+    {
+        if (serviceProvider == null)
+        {
+            throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
+        var context = (IPluginExecutionContext)serviceProvider.GetService(typeof(IPluginExecutionContext));
+        if (context.MessageName != "Update" || !context.InputParameters.Contains("Target"))
+        {
+            return;
+        }
+
+        if (!(context.InputParameters["Target"] is Entity target) || target.LogicalName != "opportunity")
+        {
+            return;
+        }
+
+        // Only run if owner is being changed
+        if (!target.Attributes.Contains("ownerid"))
+        {
+            return;
+        }
+
+        Entity preImage = null;
+        if (context.PreEntityImages.TryGetValue("PreImage", out var pre))
+        {
+            preImage = (Entity)pre;
+        }
+
+        if (preImage == null || !preImage.Attributes.Contains("ownerid"))
+        {
+            return;
+        }
+
+        var oldOwner = preImage.GetAttributeValue<EntityReference>("ownerid");
+        var newOwner = target.GetAttributeValue<EntityReference>("ownerid");
+
+        // Ignore if owner not changed
+        if (oldOwner == null || newOwner == null || oldOwner.Id == newOwner.Id)
+        {
+            return;
+        }
+
+        var factory = (IOrganizationServiceFactory)serviceProvider.GetService(typeof(IOrganizationServiceFactory));
+        var service = factory.CreateOrganizationService(context.UserId);
+
+        // Retrieve access team template for opportunity sales team
+        var templateQuery = new QueryExpression("teamtemplate")
+        {
+            ColumnSet = new ColumnSet("teamtemplateid"),
+        };
+        templateQuery.Criteria.AddCondition("objecttypecode", ConditionOperator.Equal, "opportunity");
+        templateQuery.Criteria.AddCondition("name", ConditionOperator.Equal, "Opportunity Sales Team");
+
+        var template = service.RetrieveMultiple(templateQuery).Entities.FirstOrDefault();
+        if (template == null)
+        {
+            throw new InvalidPluginExecutionException("Opportunity Sales Team template not found.");
+        }
+
+        var templateId = template.GetAttributeValue<Guid>("teamtemplateid");
+
+        // Add the previous owner to the opportunity access team
+        var addRequest = new AddUserToRecordTeamRequest
+        {
+            Record = new EntityReference("opportunity", target.Id),
+            SystemUserId = oldOwner.Id,
+            TeamTemplateId = templateId
+        };
+
+        service.Execute(addRequest);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Dynamics 365 Opportunity Plugin
+
+This repository contains a sample plug-in that automatically adds the previous owner of an opportunity to the opportunity's "Opportunity Sales Team" access team whenever the record is reassigned.
+
+## Summary
+
+When the owner of an opportunity is changed, the `AddOldOwnerToSalesTeamPlugin` runs. It uses the standard **AddUserToRecordTeamRequest** CRM message to add the previous owner to the "Opportunity Sales Team" access team. If the user is already a member of the team, the request does nothing, so duplicates are avoided.
+
+## Registration
+
+Register the plug-in on the **Update** message of the `opportunity` entity and include a pre-image named `PreImage` that contains the `ownerid` attribute. Make sure an Access Team Template exists for Opportunity with the name **"Opportunity Sales Team"**.
+
+## Building
+
+Compile the project using the CRM SDK assemblies targeting .NET Framework 4.6.2 or later. Only the plug-in class file is provided; you may include it in your existing plug-in assembly project.


### PR DESCRIPTION
## Summary
- implement AddOldOwnerToSalesTeamPlugin that adds the previous owner to the Opportunity Sales Team
- document how the plugin works and how to register it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6855037283e4833285450aa708c06332